### PR TITLE
mods: let the framework stage the catalog; route the packager through Add-ModCatalog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,22 @@ set(GAME_GENERATED_DISPATCH
 file(GLOB APE_MOD_PLUGIN_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mods/*.c")
 
+# Ape Escape's trusted, game-owned mod catalog. Every feature stays disabled
+# until selected on the launcher's Mods page.
+#
+# The FRAMEWORK stages this: PRELOADED_MODS_DIR below hands it to
+# psxrecomp_add_runtime_target(), which wipes <exe-dir>/mods/bundled and copies
+# both its own mods/builtin/packages and these packages into it, plus
+# mods/preloaded/README.md -> mods/README.md. This repo must NOT copy the tree
+# itself. It used to, with a hand-written POST_BUILD copy_directory into
+# <exe-dir>/mods, and because that named the destination as a STRING, framework
+# commit 4cc04be3's rename of the staged catalog from mods/packages to
+# mods/bundled broke it without breaking anything a configure, compile or link
+# step can see: the four ape.* packages went on landing in mods/packages, which
+# neither the launcher nor Add-ModCatalog reads, and the release packager threw
+# "Mod catalog is missing package(s) the sources define". Bead beads-eio.3.101.
+set(APE_PRELOADED_MODS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded")
+
 psxrecomp_add_runtime_target(psx-runtime
     GAME_GENERATED_FULL_C "${GAME_GENERATED_FULL}"
     GAME_GENERATED_DISPATCH_C "${GAME_GENERATED_DISPATCH}"
@@ -42,18 +58,8 @@ psxrecomp_add_runtime_target(psx-runtime
     # Per-game executable name so each title's process is distinct (killing/
     # launching one title by name never hits another's running instance).
     EXE_NAME "ApeEscapeRecomp"
+    PRELOADED_MODS_DIR "${APE_PRELOADED_MODS}"
 )
-
-# Ship Ape Escape's trusted, game-owned mod catalog beside the executable.
-# Every feature remains disabled until selected on the launcher's Mods page.
-set(APE_PRELOADED_MODS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded")
-if(EXISTS "${APE_PRELOADED_MODS}/packages")
-    add_custom_command(TARGET psx-runtime POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${APE_PRELOADED_MODS}"
-            "$<TARGET_FILE_DIR:psx-runtime>/mods"
-        COMMENT "Preloading the Ape Escape mod catalog")
-endif()
 
 if(BUILD_TESTING)
     add_executable(ape_stick_response_test

--- a/tools/package_release.ps1
+++ b/tools/package_release.ps1
@@ -3,7 +3,17 @@ param(
     # shared with tools/package_appimage.sh so Windows and Linux releases do
     # not drift.
     [string]$Version = "",
-    [string]$BuildDir = "build-release"
+    [string]$BuildDir = "build-release",
+    # Framework and launcher checkouts to build and stage from. Empty means the
+    # in-repo psxrecomp-v4 / recomp-ui submodules (normally directory junctions
+    # to the shared checkouts). Override either one to validate a release
+    # against a worktree WITHOUT moving a submodule pin -- the same
+    # -DPSXRECOMP_ROOT / -DRECOMP_UI_ROOT pattern an ordinary validation build
+    # uses. Without this the packager could only ever be exercised against
+    # whatever the submodules happen to point at, which is precisely how a
+    # framework-side layout change reaches a release packager untested.
+    [string]$FrameworkDir = "",
+    [string]$RecompUiDir = ""
 )
 
 # Ape Escape (SCUS-94423) release packager. Adapted from MegaManX6Recomp.
@@ -32,6 +42,22 @@ if (-not $Version) {
     $Version = (Get-Content -LiteralPath $VersionFile -Raw).Trim()
     if (-not $Version) { throw "$VersionFile is empty" }
 }
+if ($FrameworkDir) {
+    $FrameworkRoot = (Resolve-Path -LiteralPath $FrameworkDir).Path
+} else {
+    $FrameworkRoot = Join-Path $Root "psxrecomp-v4"
+}
+if (-not (Test-Path -LiteralPath (Join-Path $FrameworkRoot "tools\release_overlay_stage.ps1"))) {
+    throw ("No psxrecomp framework checkout at $FrameworkRoot " +
+           "(expected tools\release_overlay_stage.ps1). Run " +
+           "'git submodule update --init psxrecomp-v4', or pass " +
+           "-FrameworkDir <path-to-psxrecomp>.")
+}
+if ($RecompUiDir) {
+    $RecompUiRoot = (Resolve-Path -LiteralPath $RecompUiDir).Path
+} else {
+    $RecompUiRoot = Join-Path $Root "recomp-ui"
+}
 $BuildPath = Join-Path $Root $BuildDir
 $StageRoot = Join-Path $Root "release-stage"
 $Stage = Join-Path $StageRoot "ApeEscapeRecomp-windows-x64"
@@ -58,7 +84,8 @@ function Invoke-Native {
 
 # Build: Release, debug tools OFF, launcher ON. PSX_STATIC_RUNTIME defaults ON
 # for MinGW Release so the exe imports only system DLLs (self-contained).
-Invoke-Native { & $CMake -S $Root -B $BuildPath -G Ninja -DCMAKE_BUILD_TYPE=Release -DPSX_DEBUG_TOOLS=OFF } "cmake configure"
+Invoke-Native { & $CMake -S $Root -B $BuildPath -G Ninja -DCMAKE_BUILD_TYPE=Release -DPSX_DEBUG_TOOLS=OFF `
+    "-DPSXRECOMP_ROOT=$FrameworkRoot" "-DRECOMP_UI_ROOT=$RecompUiRoot" } "cmake configure"
 Invoke-Native { & $CMake --build $BuildPath -j $env:NUMBER_OF_PROCESSORS } "cmake build"
 
 if (Test-Path $StageRoot) {
@@ -105,21 +132,35 @@ $fontCount = (Get-ChildItem (Join-Path $Stage "assets/fonts") -Filter *.ttf -Err
 $imgCount  = (Get-ChildItem (Join-Path $Stage "assets/img")   -Filter *.tga -ErrorAction SilentlyContinue).Count
 Write-Host "Bundled recomp-ui launcher assets: $fontCount font(s) + $imgCount image(s)"
 
-# Built-in mod catalog staged by the runtime target's POST_BUILD command.
-$ModsSrc = Join-Path $BuildPath "mods"
-if (-not (Test-Path (Join-Path $ModsSrc "packages"))) {
-    throw "Built-in Ape Escape mod catalog missing at $ModsSrc"
-}
-Copy-Item -Recurse -Force $ModsSrc (Join-Path $Stage "mods")
-$manifestFiles = Get-ChildItem (Join-Path $Stage "mods/packages") -Filter manifest.toml -Recurse
-$modCount = $manifestFiles.Count
-$apeModCount = ($manifestFiles | Where-Object {
-    $_.FullName -match '\\packages\\ape\.'
-}).Count
-if ($apeModCount -ne 4) {
-    throw "Expected 4 Ape Escape mod manifests, found $apeModCount ($modCount total manifests)"
-}
-Write-Host "Bundled mod catalog: $modCount package(s), including $apeModCount Ape Escape package(s)"
+# Built-in mod catalog, staged into <build>/mods/bundled by the runtime
+# target's POST_BUILD command (psxrecomp_add_runtime_target's
+# PRELOADED_MODS_DIR stages the framework's mods/builtin/packages and this
+# repo's mods/preloaded/packages there together).
+#
+# Routed through the framework's shared Add-ModCatalog instead of the hand-
+# written block that used to live here. That block hard-coded "exactly 4 ape.*
+# manifests" and globbed mods/packages, and both halves of it were wrong:
+#
+#   * the count went stale by construction -- it describes only this title's
+#     half of a catalog the framework also contributes to, so it said nothing
+#     about whether the shared psx.* packages shipped at all (the same class of
+#     assertion that made Tomba 2 unreleasable on 2026-09-01 when the framework
+#     gained a fifth builtin);
+#   * mods/packages is the PRE-SPLIT layout. Framework 4cc04be3 moved staged
+#     build output to mods/bundled, and nothing in this repo followed, so at
+#     framework master the four ape.* packages were staged where neither the
+#     launcher nor a packager reads them (bead beads-eio.3.101).
+#
+# Add-ModCatalog asserts the invariant instead of a number: every package the
+# SOURCES define -- this repo's mods/preloaded/packages and the framework's
+# mods/builtin/packages -- must survive into the staged catalog. That cannot go
+# stale when a mod is added on either side, and it still catches the failure
+# that matters, a mod silently not shipping. It also strips the two things
+# under mods/ that belong to this machine (installed/ and state.toml).
+. (Join-Path $FrameworkRoot "tools\release_overlay_stage.ps1")
+Add-ModCatalog -BuildPath $BuildPath -Stage $Stage `
+               -GameModSource (Join-Path $Root "mods\preloaded") `
+               -FrameworkModSource (Join-Path $FrameworkRoot "mods\builtin") | Out-Null
 
 # Player-facing game.toml: copy the REAL game.toml (the single source of truth
 # for all runtime/video/controller/widescreen config) minus the dev-only [audit]


### PR DESCRIPTION
## What

This repo staged its own mod catalog with a hand-written POST_BUILD `copy_directory` into `$<TARGET_FILE_DIR:psx-runtime>/mods`, and `mods/preloaded` contains `packages/`, so the four `ape.*` packages landed in `<exe>/mods/packages`. Framework commit `4cc04be3` renamed the staged catalog to `<exe>/mods/bundled` — the framework's staging, the launcher's scan and the shared release module all moved — and nothing here followed, because that destination is a **string** with no compile-time or link-time consumer. At framework master this repo built and linked perfectly while staging its entire Mods page where nothing reads it.

Bead `beads-eio.3.101`. Framework fix: **mstan/psxrecomp#305**.

`CMakeLists.txt` now declares the directory instead of copying it, via the `PRELOADED_MODS_DIR` argument that PR adds. The layout string lives in exactly one place, so the next rename does not touch this file.

## Measured — real build output

Framework `fix/framework-owns-mod-catalog-staging`, recomp-ui `d8187a4`, `-DCMAKE_BUILD_TYPE=Release`:

```
Staging mod catalog for psx-runtime (8 package(s) -> mods/bundled)
-- [psx-runtime] staged mod catalog OK: 8 package(s) = 4 game-owned + 4 framework-owned,
   all under mods/bundled, no mods/packages

mods/README.md
mods/bundled/ape.enhancement.frame-smoothing/1.0.0/manifest.toml
mods/bundled/ape.enhancement.quick-gadget-select/1.0.0/manifest.toml
mods/bundled/ape.enhancement.skip-fmvs/1.0.0/manifest.toml
mods/bundled/ape.enhancement.widescreen/1.0.0/manifest.toml
mods/bundled/psx.enhancement.cd-speed/1.0.0/manifest.toml
mods/bundled/psx.enhancement.fast-loading/1.0.0/manifest.toml
mods/bundled/psx.enhancement.pgxp/1.0.0/manifest.toml
mods/bundled/psx.presentation.bezel/1.0.0/manifest.toml
```

No `mods/packages`, no `mods/state.toml`, no `mods/installed`. Matches `packaging/release/app.conf` `EXPECTED_MODS=8`.

```
100% tests passed, 0 tests failed out of 3
  ape_stick_response_test / ape_preloaded_mods_test / psx_staged_mod_catalog_test
```

`psx_staged_mod_catalog_test` is registered automatically by the framework once a catalog is declared.

## The packager needed more than a path change

`tools/package_release.ps1` did not use the shared release module at all. Its own inline block globbed `mods/packages` and asserted "exactly 4 `ape.*` manifests". Both halves were wrong:

* `mods/packages` is the pre-split layout, so at framework master `Test-Path` threw `Built-in Ape Escape mod catalog missing at ...` — and after the CMakeLists fix it would have thrown again, since that directory no longer exists;
* the count described only *this* repo's half of a catalog the framework also contributes to. It said nothing about whether the shared `psx.*` packages shipped, and it is the same shape of assertion that made Tomba 2 unreleasable on 2026-09-01 when the framework gained a fifth builtin — which is why `Add-ModCatalog` was written to replace exactly these three per-title counts (Tomba 2 `-ne 5`, MegaManX6 `-lt 16`, Ape Escape `-ne 4`).

It now dot-sources `psxrecomp-v4/tools/release_overlay_stage.ps1` and calls `Add-ModCatalog`, which asserts the **invariant**: every package the sources define — `mods/preloaded/packages` here and `mods/builtin/packages` in the framework — must survive into the staged catalog. That cannot go stale when a mod is added on either side, and it still catches a mod silently not shipping. It also strips `installed/` and `state.toml`, which the old block did not.

New `-FrameworkDir` / `-RecompUiDir` parameters (empty = the in-repo submodules, as before) exist because a packager that can only be run against whatever the submodules point at cannot be exercised against a framework branch — precisely how a framework-side layout change reaches a release packager untested. This defect was found while designing the Ape packager migration and could not have been validated without them.

Full run, exit 0:

```
Bundled recomp-ui launcher assets: 4 font(s) + 10 image(s)
Bundled mod catalog: 8 package(s) = 4 game-owned + 4 framework-owned
Staged player game.toml from real game.toml (audit section stripped)
Verified self-contained: imports only system DLLs (16 total)
Wrote ...\ApeEscapeRecomp-v0.2.1-windows-x64.zip
```

Artifact extracted rather than assumed: 8 `manifest.toml` under `mods\bundled`, `mods\README.md` present, **zero** `mods\packages` entries, zero `mods\state.toml` / `mods\installed` entries.

`tools/package_appimage.sh` and `tools/test_appimage_layout.sh` needed no change — they copy `mods/` wholesale and count `manifest.toml` recursively, so they never named the subdirectory, and `EXPECTED_MODS=8` was already right here.

## Shipped releases are not affected

An older release pins a framework from before the split and is self-consistent with it. **This is a forward break only.**

## Merge order

**mstan/psxrecomp#305 must merge FIRST.** `PRELOADED_MODS_DIR` does not exist before it, so this PR cannot configure against framework master until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
