### PR TITLE
Fix Ape AppImage shared staging build path

### DIFF
--- a/tools/package_appimage.sh
+++ b/tools/package_appimage.sh
@@ -216,6 +216,7 @@ if [ "$skip_build" = "0" ]; then
     # otherwise identical builds differ.
     cmake -S "$root" -B "$build_dir" -G "$generator" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DPSX_SDL_BACKEND=SDL2 \
         -DPSX_DEBUG_TOOLS=OFF \
         -DCMAKE_EXE_LINKER_FLAGS="-Wl,--build-id=none"
     cmake --build "$build_dir" --target psx-runtime -j "$jobs"
@@ -263,6 +264,13 @@ game_id=$(sed -n 's/^[[:space:]]*id[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' 
 
 recompiler_bin=$fw/$bios_build/psxrecomp-game
 [ -x "$recompiler_bin" ] || recompiler_bin=$fw/recompiler/build-linux/psxrecomp-game
+if [ ! -x "$recompiler_bin" ]; then
+    recompiler_build=$(dirname -- "$recompiler_bin")
+    gen=Ninja
+    command -v ninja >/dev/null 2>&1 || gen="Unix Makefiles"
+    cmake -S "$fw/recompiler" -B "$recompiler_build" -G "$gen" -DCMAKE_BUILD_TYPE=Release
+    cmake --build "$recompiler_build" --target psxrecomp-game -j "$jobs"
+fi
 cg_tag=$(psx_overlay_cg_tag \
     --runtime-include "$fw/runtime/include" \
     --recompiler "$recompiler_bin" \


### PR DESCRIPTION
Brings the Ape AppImage packager in line with the Tomba 2 Linux path: use SDL2 explicitly under WSL/Linux and build the Linux psxrecomp-game binary before asking the shared release staging helper for the codegen tag.\n\nValidation:\n- Regenerated game C in a clean worktree from pinned psxrecomp a7459cdd.\n- Built Linux cache from fresh release capture: PSX_SHARD_RESULT ok=1 failed=0 skipped=0.\n- bash tools/package_appimage.sh --jobs 14 succeeded.\n- Extracted AppImage: 1 staged Linux .so shard; overlay_toolchain present with 3925 files including overlay_dispatch_preamble.c.inc and bios/SCPH1001.toml.\n- Extracted AppRun soak under WSLg for 180s with APE_ESCAPE_RECOMP_DATA_DIR outside payload.\n- psx_last_run_report.json: autocompile_degraded=0, active=1, loads=1, regions_checked=3, registered=26, valid_count=26, last_file_found=1, disp_native=915; capture file written.