### PR TITLE
Update pinned linuxdeploy AppImage hash

### DIFF
--- a/tools/package_appimage.sh
+++ b/tools/package_appimage.sh
@@ -348,7 +348,7 @@ ln -s "$DESKTOP_ID.png" "$appdir/.DirIcon"
 
 # --- pinned tooling --------------------------------------------------------
 linuxdeploy_url=https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-linuxdeploy_sha=421ca71d5c69ea97c6309276232990d43df1dcece0edfaa26bbf926ff96ed12e
+linuxdeploy_sha=36a2d7e274d12e1050d0e9ecfe11d339ed54720b2bec464c286d53f8b07f5c62
 appimagetool_url=https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
 appimagetool_sha=a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0
 


### PR DESCRIPTION
Updates the pinned linuxdeploy continuous AppImage SHA256 to the currently published artifact hash. This unblocks clean AppImage packaging with the existing hash-checked fetch path.